### PR TITLE
Use tempfile.gettempdir() instead of hard-coded /tmp

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@ import os
 import time
 import duckdb
 import pprint
+import tempfile
 
 from pathlib import Path
 from argparse import ArgumentParser, Namespace
@@ -74,7 +75,7 @@ if __name__ == '__main__':
         pqt_files = [str(f) for f in args.files]
     else:
         # Convert the file(s) to parquet
-        dst_dir = "/tmp" if DOCKERIZED else f"{os.getcwd()}/parquet"
+        dst_dir = tempfile.gettempdir() if DOCKERIZED else f"{os.getcwd()}/parquet"
         pqt_files = read_files(args.files, dst_dir=dst_dir, filetype=filetype, nr_processes=args.n)
         duration = time.time()-start
         LOGGER.info(f"Conversion took {duration:.2f}s")


### PR DESCRIPTION
Ran into problems with /tmp not being big enough for large pcaps on a new debian installation (which uses RAM based tmpfs as /tmp by default). 
Replacing hard-coded use of /tmp with tempfile.gettempdir() makes it possible to use alternative tmp directory if this occurs (by setting TMPDIR env variable to a disk based directory).

tempfile.gettempdir() will return the platform specific temp dir if no env vars are set (so by default it will return /tmp for linux/mac systems), see https://docs.python.org/library/tempfile.html#tempfile.gettempdir
