### PR TITLE
Fix implicit cast error with new duckdb version (Issue #72)

### DIFF
--- a/src/reader.py
+++ b/src/reader.py
@@ -75,7 +75,7 @@ class Pcap2Parquet:
         'icmp.type': {'icmp_type': pa.uint8()},
         'ip.frag_offset': {'ip_frag_offset': pa.uint16()},
         'ip.ttl': {'ip_ttl': pa.uint8()},
-        'ntp.priv.reqcode': {'ntp_priv_reqcode': pa.string()},
+        'ntp.priv.reqcode': {'ntp_priv_reqcode': pa.uint8()},
         'tcp.dstport': {'tcp_dstport': pa.uint16()},
         'tcp.srcport': {'tcp_srcport': pa.uint16()},
         'udp.dstport': {'udp_dstport': pa.uint16()},


### PR DESCRIPTION
Duckdb v0.10.0 is slightly more restrictive in implicit casting. This highlighted that one of the exported pcap fields (ntp.priv.reqcode)  was exported as the wrong type (as string when it should have been an uint8). Until now unnoticed because of implcit casting by earlier duckdb versions. 
Solves Issue #72